### PR TITLE
Bug fix for RT 107921

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for the Perl MegaHAL extension.
 
+0.08_01   Not yet released
+        - Fix for RT 107921 (format not a string literal and no format
+           arguments)
+
 0.08 = 0.07_01 2015-04-12
 
 0.07_01   Apr 14 2012

--- a/libmegahal.c
+++ b/libmegahal.c
@@ -720,7 +720,7 @@ char *read_input(char *prompt)
     /*
      *		Display the prompt to the user.
      */
-    fprintf(stdout, prompt);
+    fputs(prompt, stdout);
     fflush(stdout);
 
     /*
@@ -743,7 +743,7 @@ char *read_input(char *prompt)
 	 */
 	if((char)(c)=='\n') {
 	    if(finish==TRUE) break;
-	    fprintf(stdout, prompt);
+	    fputs(prompt, stdout);
 	    fflush(stdout);
 	    finish=TRUE;
 	    c=32;
@@ -897,7 +897,7 @@ bool print_header(FILE *file)
 
     fprintf(file, "MegaHALv8\n");
     fprintf(file, "Copyright (C) 1998 Jason Hutchens\n");
-    fprintf(file, timestamp);
+    fputs(timestamp, file);
     fflush(file);
 
     return(TRUE);
@@ -2880,7 +2880,7 @@ void delay(char *string)
      *		Don't simulate typing if the feature is turned off
      */
     if(typing_delay==FALSE)	{
-	fprintf(stdout, string);
+	fputs(string, stdout);
 	return;
     }
 


### PR DESCRIPTION
Hello,

Here's a tentative fix for the [bug reported today](https://rt.cpan.org/Ticket/Display.html?id=107921). It certainly allows the compilation to proceed and after a manual link the tests pass OK. That said, the tests may not be fully exercising those parts of the lib which have been changed so a bit of manual validation would probably be advisable (by someone more familiar with the module than I am) before merging.

I hope this PR is useful.

Pete
