### PR TITLE
Adding MIN_PERL_VERSION to Makefile.PL

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for the Perl MegaHAL extension.
 
+0.08_01   Not yet released
+        - MIN_PERL_VERSION added to Makefile.PL
+
 0.08 = 0.07_01 2015-04-12
 
 0.07_01   Apr 14 2012

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,6 +20,7 @@ WriteMakefile1(
     BUILD_REQUIRES    => {
         'Test::More'      => '0.47',
     },
+    MIN_PERL_VERSION  => '5.005',
     $^O =~/win/i ? (
         dist => {
             TAR      => 'ptar',


### PR DESCRIPTION
This adds the minumum Perl version (5.005) to the Makefile.PL as [suggested by CPANTS](http://cpants.cpanauthors.org/dist/AI-MegaHAL-0.08). The boilerplate at the end of Makefile.PL already removes this entry if the version of ExtUtils::MakeMaker is too old so it must have been expected. 5.005 is the version suggested by perlver and I've not spotted anything which would contradict that.
